### PR TITLE
fix(packaging): Dockerfile `go-sqlite3 requires cgo to work`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.16.6-alpine3.14 as builder
 
 WORKDIR /src
 
-RUN apk add --update git && rm -rf /var/cache/apk/*
+RUN apk add --update git musl-dev gcc && rm -rf /var/cache/apk/*
 
 COPY go.mod .
 COPY go.sum .
@@ -15,14 +15,10 @@ COPY core ./core
 COPY handlers ./handlers
 COPY repositories ./repositories
 
-RUN CGO_ENABLED=0 \
-    GOOS=linux \
-    go build -a -installsuffix cgo -o /dist/todolist-api .
-
+RUN go build -a -ldflags "-linkmode external -extldflags '-static' -s -w" -o /dist/todolist-api .
 # Runtime
 FROM scratch
 
 COPY --from=builder /dist/todolist-api /todolist-api
 
-ENTRYPOINT ["/todolist-api"]
-
+ENTRYPOINT [ "/todolist-api"]


### PR DESCRIPTION
Dockerfile broky -> google -> stackoverflow

https://stackoverflow.com/questions/57921746/binary-was-compiled-with-cgo-enabled-0-go-sqlite3-requires-cgo-to-work-this